### PR TITLE
Use equal operator instead of identical (===) for cmyk parameter.

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -41,7 +41,7 @@ if ($parsed_url != false){
     // Convert pdf in CMYK colorspace
     // Need GhostScript
     // Need a writeable temporary directory for php process
-    if (isset($_GET['cmyk']) && $_GET['cmyk'] === 1) {
+    if (isset($_GET['cmyk']) && $_GET['cmyk'] == 1) {
         
         $tmpRGBFileName = tempnam(sys_get_temp_dir(), 'pdf-rgb');
         $tmpCMYKFileName = tempnam(sys_get_temp_dir(), 'pdf-cmyk');


### PR DESCRIPTION
Since $_GET parameters are strings, $_GET['cmyk'] === 1 was always false.

I used == instead of ===.
We could also do : 
```php
if (isset($_GET['cmyk']) && $_GET['cmyk'])
// But it's going to be true for 2, 3 or potato
```
Or : 
```php
if (isset($_GET['cmyk']) && intval($_GET['cmyk']) == 1)
```
Or even, to keep the identical operator : 
```php
if (isset($_GET['cmyk']) && $_GET['cmyk'] === '1')
```
I don't know if you have some guidelines / preferences for those things :).