### PR TITLE
Disable autorotate in ghostscript during CMYK conversion

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -52,7 +52,7 @@ if ($parsed_url != false){
         fclose($tmpRGBFile);
         
         // Convert to CMYK with GhostScript command
-        exec('gs -o '.$tmpCMYKFileName.' -sDEVICE=pdfwrite -sProcessColorModel=DeviceCMYK -sColorConversionStrategy=CMYK -sColorConversionStrategyForImages=CMYK '.$tmpRGBFileName);
+        exec('gs -o '.$tmpCMYKFileName.' -dAutoRotatePages=/None -sDEVICE=pdfwrite -sProcessColorModel=DeviceCMYK -sColorConversionStrategy=CMYK -sColorConversionStrategyForImages=CMYK '.$tmpRGBFileName);
         
         //Display output in stream
         $tmpCMYKFile = fopen($tmpCMYKFileName,'rb');


### PR DESCRIPTION
By default ghostscript has AutoRotatePages set to PageByPage meaning it will decide to automatically flip a page from portrait to landscape or vice versa if the majority of the text has the "wrong" orientation.
Since we are using ghostscript for the CMYK feature it's probably better not to change anything else than the colorspace during conversion. Thus, I added -dAutoRotatePages to /None during gs call.