### PR TITLE
Fix CMYK conversion sometimes breaking image quality.

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -44,7 +44,7 @@ if ($parsedUrl != false) {
         fclose($tmpRGBFile);
 
         // Convert to CMYK with GhostScript command
-        exec('gs -o '.$tmpCMYKFileName.' -dAutoRotatePages=/None -sDEVICE=pdfwrite -sProcessColorModel=DeviceCMYK -sColorConversionStrategy=CMYK -sColorConversionStrategyForImages=CMYK '.$tmpRGBFileName);
+        exec('gs -o '.$tmpCMYKFileName.' -dAutoRotatePages=/None -sDEVICE=pdfwrite -sProcessColorModel=DeviceCMYK -sColorConversionStrategy=CMYK -dAutoFilterColorImages=false -dColorImageFilter=/FlateEncode '.$tmpRGBFileName);
 
         //Display output in stream
         $tmpCMYKFile = fopen($tmpCMYKFileName, 'rb');


### PR DESCRIPTION
This PR prevents ghostscript from applying JPEG encoding on images.
We tell ghostscript to use FlateEncode which is a lossless encoding algorithm instead of the default DCTEncode.
I removed -sColorConversionStrategyForImages which is useless since it doesn't even exists in ghostscript.